### PR TITLE
Add method to request the canvas snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>sketch-canvas-root</artifactId>
 	<packaging>pom</packaging>
-	<version>0.4</version>
+	<version>0.5</version>
 	<name>SketchCanvas Add-on Root Project</name>
 
 	<prerequisites>

--- a/sketch-canvas-addon/pom.xml
+++ b/sketch-canvas-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>sketch-canvas</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4</version>
+	<version>0.5</version>
 	<name>Sketch Canvas Add-on</name>
 
 	<prerequisites>

--- a/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
+++ b/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
@@ -33,8 +33,8 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
    * Image data consumer
    * @param <String> svg or base64 image
    */
-  public interface ImageDataConsumer<String> {
-    void consume(String imageData);
+  public interface ImageDataConsumer<T> {
+    void consume(T imageData);
   }
 
   /**
@@ -64,9 +64,10 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
 
   private ArrayList<DrawingChangeListener> drawingChangeListeners = new ArrayList<DrawingChangeListener>();
 
-  private Optional<ImageDataConsumer<String>> optionalSVGConsumer;
-  private Optional<ImageDataConsumer<String>> optionalImageConsumer;
-
+  private Optional<ImageDataConsumer<String>> optionalSVGConsumer = Optional.empty();
+  private Optional<ImageDataConsumer<String>> optionalImageConsumer = Optional.empty();
+  private Optional<ImageDataConsumer<String>> optionalDrawingSnapshotConsumer = Optional.empty();
+  
   /**
    * Initialize full sized
    */
@@ -160,7 +161,7 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
    * @param svgConsumer
    */
   public void requestImageAsSVGString(ImageDataConsumer<String> svgConsumer) {
-    this.optionalSVGConsumer = Optional.of(svgConsumer);
+    this.optionalSVGConsumer = Optional.ofNullable(svgConsumer);
     callFunction("requestSVG");
   }
 
@@ -169,8 +170,13 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
    * @param imageConsumer
    */
   public void requestImageAsBase64(ImageDataConsumer<String> imageConsumer) {
-    this.optionalImageConsumer = Optional.of(imageConsumer);
+    this.optionalImageConsumer = Optional.ofNullable(imageConsumer);
     callFunction("requestImage");
+  }
+  
+  public void requestCanvasSnapshot(ImageDataConsumer<String> drawingSnapshotConsumer) {
+	this.optionalDrawingSnapshotConsumer = Optional.ofNullable(drawingSnapshotConsumer);
+	callFunction("requestSnapshot");
   }
 
   /**
@@ -224,6 +230,11 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
       optionalImageConsumer.ifPresent(consumer -> {
         consumer.consume(arguments.getString(0));
       });
+    });
+    addFunction("setSnapshot", snapshot -> {
+    	optionalDrawingSnapshotConsumer.ifPresent(consumer -> {
+    		consumer.consume(snapshot.getString(0));
+    	});
     });
   }
 

--- a/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
+++ b/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
@@ -31,7 +31,7 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
 
   /**
    * Image data consumer
-   * @param <String> svg or base64 image
+   * @param <T> svg, base64 image or the snapshot of the canvas as a JSON string
    */
   public interface ImageDataConsumer<T> {
     void consume(T imageData);

--- a/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
+++ b/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
@@ -76,7 +76,7 @@ window.org_vaadin_SketchCanvas =
         this.clearDrawing = function () {
             lc.clear();
         };
-
+        
         function removeSelectedClassNameFromPreviousTool() {
             var previousToolElement = element.querySelector("div.lc-pick-tool[title=" + currentToolName + "]");
             if (previousToolElement) {
@@ -96,7 +96,7 @@ window.org_vaadin_SketchCanvas =
         }
 
         this.setSelectedTool = function (tool, storeWidth) {
-            // TODO update css selected classname 
+            // TODO update css selected classname
             switch (tool) {
                 case "Pencil" :
                     var pencil = new LC.tools.Pencil(lc);
@@ -196,5 +196,10 @@ window.org_vaadin_SketchCanvas =
         this.requestImage = function() {
             var imgData = lc.getImage().toDataURL();
             self.setImageData(imgData);
+        };
+        
+        this.requestSnapshot = function() {
+        	var snapshot= JSON.stringify(lc.getSnapshot());
+        	this.setSnapshot(snapshot);
         };
     };

--- a/sketch-canvas-demo/pom.xml
+++ b/sketch-canvas-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin</groupId>
 	<artifactId>sketch-canvas-demo</artifactId>
 	<packaging>war</packaging>
-	<version>0.4</version>
+	<version>0.5</version>
 	<name>MyComponent Add-on Demo</name>
 
 	<prerequisites>


### PR DESCRIPTION
In order to enable saving and loading of canvas state we need a snapshot in a format that LiterallyCanvas understands. 

The method `updateDrawing` loads that json but I couldn't find a method to get the current snapshot. This PR is about getting that snapshot out of LC.