### PR TITLE
Fixes and additional features

### DIFF
--- a/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
+++ b/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
@@ -85,6 +85,24 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
   }
 
   /**
+   * Set the image in the given url as a background image
+   *
+   * @param url
+   */
+  public void setBackgroundImage(String url) {
+    if (url != null) {
+      callFunction("setBackgroundImage", url);
+    }
+  }
+
+  /**
+   * Remove the background image from the c
+   */
+  public void clearBackgroundImage() {
+    callFunction("setBackgroundImage", "");
+  }
+
+  /**
    * Update canvas with given json snapshot
    *
    * @param json

--- a/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
+++ b/sketch-canvas-addon/src/main/java/org/vaadin/SketchCanvas.java
@@ -67,7 +67,7 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
   private Optional<ImageDataConsumer<String>> optionalSVGConsumer = Optional.empty();
   private Optional<ImageDataConsumer<String>> optionalImageConsumer = Optional.empty();
   private Optional<ImageDataConsumer<String>> optionalDrawingSnapshotConsumer = Optional.empty();
-  
+
   /**
    * Initialize full sized
    */
@@ -81,7 +81,17 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
    * @param json
    */
   public void updateDrawing(JsonArray json) {
-    callFunction("updateDrawing", json.get(0));
+    callFunction("updateDrawing", json.get(0), true);
+  }
+
+  /**
+   * Update canvas with given json snapshot
+   *
+   * @param json
+   * @param ignoreColorChanges false if you want the colors of the snapshot to be set for the canvas
+   */
+  public void updateDrawing(JsonArray json, boolean ignoreColorChanges) {
+    callFunction("updateDrawing", json.get(0), ignoreColorChanges);
   }
 
   /**
@@ -173,7 +183,7 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
     this.optionalImageConsumer = Optional.ofNullable(imageConsumer);
     callFunction("requestImage");
   }
-  
+
   public void requestCanvasSnapshot(ImageDataConsumer<String> drawingSnapshotConsumer) {
 	this.optionalDrawingSnapshotConsumer = Optional.ofNullable(drawingSnapshotConsumer);
 	callFunction("requestSnapshot");
@@ -279,7 +289,7 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
       return new ByteArrayInputStream(Base64.getDecoder().decode(imgData.split(",")[1].getBytes(StandardCharsets.UTF_8)));
     }, fileName);
   }
-  
+
   /**
    * Set the width of the canvas
    * @param width the width of the canvas or {@code null} for infinite
@@ -295,5 +305,5 @@ public class SketchCanvas extends AbstractJavaScriptComponent {
   public void setCanvasHeight(Integer height) {
 	getState().canvasHeight = height;
   }
-  
+
 }

--- a/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
+++ b/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
@@ -206,9 +206,13 @@ window.org_vaadin_SketchCanvas =
             var imgData = lc.getImage().toDataURL();
             self.setImageData(imgData);
         };
-        
+
         this.requestSnapshot = function() {
         	var snapshot= JSON.stringify(lc.getSnapshot());
         	this.setSnapshot(snapshot);
         };
+
+        this.addResizeListener(element, function() {
+          lc.respondToSizeChange();
+        });
     };

--- a/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
+++ b/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
@@ -67,10 +67,13 @@ window.org_vaadin_SketchCanvas =
             {imageSize: {width: width, height: height}}
         );
 
-        this.updateDrawing = function (snapshot) {
+        this.updateDrawing = function (snapshot, ignoreColorChanges) {
             loadingSnapshot = true;
             lc.loadSnapshot(JSON.parse(snapshot));
-            restoreOriginalColors();
+
+            if (ignoreColorChanges)
+              restoreOriginalColors();
+
             loadingSnapshot = false;
         };
 

--- a/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
+++ b/sketch-canvas-addon/src/main/resources/VAADIN/sketchcanvas/js/sketchcanvas-connector.js
@@ -10,8 +10,9 @@ window.org_vaadin_SketchCanvas =
 
         var canvasWidth = null;
         var canvasHeight = null;
-        
+
         var loadingSnapshot = false;
+        var backgroundImageUrl = null;
 
         var currentToolName;
         var currentPColor = "black";
@@ -33,7 +34,7 @@ window.org_vaadin_SketchCanvas =
                 evt.initEvent("resize", false, true);
                 window.dispatchEvent(evt);
             }
-            
+
             if (canvasWidth !== state.canvasWidth || height !== state.canvasHeight) {
             	canvasWidth = state.canvasWidth;
             	canvasHeight = state.canvasHeight;
@@ -88,7 +89,7 @@ window.org_vaadin_SketchCanvas =
         this.clearDrawing = function () {
             lc.clear();
         };
-        
+
         function removeSelectedClassNameFromPreviousTool() {
             var previousToolElement = element.querySelector("div.lc-pick-tool[title=" + currentToolName + "]");
             if (previousToolElement) {
@@ -200,12 +201,39 @@ window.org_vaadin_SketchCanvas =
             }
         });
 
+        this.setBackgroundImage = function(url) {
+          backgroundImageUrl = url;
+          self.updateBackground(url);
+          lc.respondToSizeChange();
+        };
+
+        this.updateBackground = function(url) {
+          loadingSnapshot = true;
+          if (url || url != '') {
+            var newImage = new Image();
+            newImage.style.width = '100%';
+            newImage.style.height = '100%';
+            newImage.src = self.translateVaadinUri(url);
+
+            lc.backgroundShapes = [LC.createShape('Image', {
+              x: 0,
+              y: 0,
+              image: newImage,
+              scale: 1
+            })];
+          } else {
+            lc.backgroundShapes = [];
+          }
+          loadingSnapshot = false;
+        }
+
         this.requestSVG = function() {
             var svgStr = lc.getSVGString();
             self.setSVGString(svgStr);
         };
 
         this.requestImage = function() {
+            self.updateBackground(backgroundImageUrl);
             var imgData = lc.getImage().toDataURL();
             self.setImageData(imgData);
         };


### PR DESCRIPTION
1. e0ec80b65282da9f63cee0415a75592a29f8937e Adds resize listener which is needed to avoid glitches that occasionally happen when the size of canvas changes
1. d5f0a3f7c8c7d68a29f0953d9fc42370d2033967 Adds option to preserve the color when updating the canvas from a snapshot
1. d562bd42e1a18ede5ba97914ad685d32c2fde5b3 Adds helper for the cases when a background image is needed. Has a limited functionality at the moment as only an image URL which can use a Vaadin format can be added on 0,0
